### PR TITLE
Fixed scrapeSeason() not working.

### DIFF
--- a/lib/anime_parser.js
+++ b/lib/anime_parser.js
@@ -466,10 +466,7 @@ export const scrapeAnimeDetails = async({ id }) => {
 
 export const scrapeSeason = async({ list = [], season, page = 1 }) => {
     try {
-        const season_page = await axios.get(`
-                ${seasons_url}
-        ${season}?page=${page}
-    `)
+        const season_page = await axios.get(`${seasons_url}${season}?page=${page}`)
         const $ = cheerio.load(season_page.data)
 
         $('div.last_episodes > ul > li').each((i, el) => {


### PR DESCRIPTION
scrapeSeason() was not working because the url in the axios request was split over multiple lines and newline characters were being added into the url by the system which caused a 404 error. Simply removing the spaces in the url and moving it into a single line fixed it.